### PR TITLE
fix: loadout card rendering and weapon allocation (v3.1.0)

### DIFF
--- a/Modules/Core.cs
+++ b/Modules/Core.cs
@@ -24,7 +24,7 @@ public class Core : BasePlugin, IPluginConfig<RetakesAllocatorConfig>
     public static Core Plugin = null!;
 
     public override string ModuleName => "[Retakes] Weapons Allocator";
-    public override string ModuleVersion => "3.0.0";
+    public override string ModuleVersion => "3.1.0";
     public override string ModuleAuthor => "Ravid & B3none";
     public override string ModuleDescription => "Weapons Allocator plugin for retakes";
 

--- a/Modules/Handlers/Events.cs
+++ b/Modules/Handlers/Events.cs
@@ -21,16 +21,22 @@ internal static class Events
 
     private static HookResult OnRoundPreStart(EventRoundPrestart @event, GameEventInfo info)
     {
-        if (GetGameRules().WarmupPeriod)
+        var warmup = GetGameRules() is { WarmupPeriod: true };
+
+        // A warmup round still must not count towards the pistol-round tally.
+        if (warmup)
         {
             _ignoreRoundEnd = true;
-            return HookResult.Continue;
         }
 
+        // These two run in warmup as well. The nade pools are shared by every player and refilled
+        // per round, so skipping this while players are spawning drains them across warmup respawns
+        // and never refills; SetupPlayers is what decides who carries the AWP.
         SetupPlayers(Players);
         ResetNades();
 
-        if(CurrentVote != null && CurrentVote.Vote.OnlyHeadshots)
+        // The vote belongs to the match, not to warmup.
+        if(!warmup && CurrentVote != null && CurrentVote.Vote.OnlyHeadshots)
         {
             mp_damage_headshot_only.SetValue(true);
         }
@@ -54,11 +60,9 @@ internal static class Events
 
     private static HookResult OnPlayerSpawn(EventPlayerSpawn @event, GameEventInfo info)
     {
-        if(GetGameRules().WarmupPeriod)
-        {
-            return HookResult.Continue;
-        }
-
+        // No warmup guard here any more. Newer retakes builds let players spawn during warmup, and
+        // bailing out left them with nothing at all; Timer_GiveWeapons decides what a warmup spawn
+        // gets, which is the same loadout a normal round gives.
         var playerController = @event.Userid;
 
         if (playerController == null! || !playerController.IsValid)

--- a/Modules/Models/Player.cs
+++ b/Modules/Models/Player.cs
@@ -2,6 +2,7 @@ using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Utils;
 using RetakesAllocator.Modules.Weapons;
+using Timer = CounterStrikeSharp.API.Modules.Timers.Timer;
 
 using static RetakesAllocator.Modules.Core;
 
@@ -22,6 +23,18 @@ public class Player
 
     public static void SetupPlayers(List<Player> players)
     {
+        // No AWP in warmup. This still runs there so the nade pool is refilled, but nobody wins the
+        // roll for a round that is not being played.
+        if (GetGameRules() is { WarmupPeriod: true })
+        {
+            foreach (var warmupPlayer in players)
+            {
+                warmupPlayer.WeaponsAllocator.ShouldGiveAwp = false;
+            }
+
+            return;
+        }
+
         List<Player> playersT = new();
         List<Player> playersCt = new();
 
@@ -95,21 +108,89 @@ public class Player
         return !(Controller == null! || !Controller.IsValid);
     }
 
+    private Timer? _spawnTimer;
+
+    /// <summary>
+    /// Applies a saved loadout immediately, so the menu's result is visible now instead of next
+    /// spawn - but only the slots that actually changed for the team this player is on.
+    /// </summary>
+    /// <remarks>
+    /// The caller decides what changed, because only it knows what the values were before the edit.
+    /// Editing the CT weapons while playing T changes nothing here, and changing only the rifle
+    /// leaves the pistol in hand rather than re-issuing it.
+    ///
+    /// Grenades and armour are never re-issued: grenades come from a pool shared by everyone and
+    /// refilled once per round, so a player could drain it by reopening the menu and saving.
+    /// </remarks>
+    public void ApplyLoadoutChange(bool primaryChanged, bool secondaryChanged)
+    {
+        if (!primaryChanged && !secondaryChanged)
+        {
+            return;
+        }
+
+        if (!IsValid() || !Controller.PawnIsAlive)
+        {
+            return;
+        }
+
+        // A pistol round and a vote both deliberately override the saved loadout, so applying it
+        // now would hand out weapons this round is not supposed to allow. Warmup has no such rules.
+        if (GetGameRules() is not { WarmupPeriod: true })
+        {
+            if (RoundsCounter < Core.Config.PistolRound.RoundAmount || CurrentVote != null!)
+            {
+                return;
+            }
+        }
+
+        if (primaryChanged)
+        {
+            WeaponsAllocator.ReplacePrimary();
+        }
+
+        if (secondaryChanged)
+        {
+            WeaponsAllocator.ReplaceSecondary();
+        }
+    }
+
     public void CreateSpawnDelay()
     {
-        Plugin.AddTimer(.1f, Timer_GiveWeapons);
+        // player_spawn fires more than once around a single spawn - on the pawn appearing and again
+        // on team assignment. Each one used to queue its own timer, and since allocation only ever
+        // gives and never strips, the extras stacked a second full loadout. Keep one timer.
+        _spawnTimer?.Kill();
+        _spawnTimer = Plugin.AddTimer(.1f, Timer_GiveWeapons);
     }
 
     private void Timer_GiveWeapons()
     {
-        if(RoundsCounter < Core.Config.PistolRound.RoundAmount)
+        _spawnTimer = null;
+
+        if (!IsValid())
+        {
+            return;
+        }
+
+        // Every branch below only ever gives, so clear first and allocating twice is harmless
+        // instead of doubling. This is the one place all three allocation paths pass through.
+        WeaponsAllocator.ClearAllocatedWeapons();
+
+        // Warmup is not a round. Newer retakes builds spawn players during it, and neither of the
+        // two things that shape a real round applies there: pistol rounds are counted from round 0
+        // and a vote is for the match, so warmup hands out the player's configured loadout instead.
+        // `is { }` keeps this safe if the game rules entity cannot be resolved.
+        var warmup = GetGameRules() is { WarmupPeriod: true };
+
+        if(!warmup && RoundsCounter < Core.Config.PistolRound.RoundAmount)
         {
             WeaponsAllocator.AllocatePistolRound();
             WeaponsAllocator.AllocateArmor(false);
             return;
         }
 
-        if(CurrentVote == null!)
+        if(warmup || CurrentVote == null!)
         {
             WeaponsAllocator.Allocate();
             WeaponsAllocator.AllocateNades();

--- a/Modules/Weapons/Allocator.cs
+++ b/Modules/Weapons/Allocator.cs
@@ -1,3 +1,4 @@
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Utils;
 using CounterStrikeSharp.API.Modules.Entities.Constants;
@@ -134,6 +135,77 @@ public class Allocator(Player player)
             CsItem.SmokeGrenade => nades.HasSmokes(),
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Empties the two slots allocation is about to refill, so giving a loadout twice leaves the
+    /// player with one of each instead of two. Every allocation path only ever gives, so without
+    /// this a duplicated spawn event stacks a second full loadout.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT <c>RemoveWeapons()</c>: that also takes the C4, which the retakes plugin
+    /// hands to a terrorist at round start, before this runs 0.1s after spawn. The bomb has a slot
+    /// of its own and is never cleared here.
+    ///
+    /// The knife IS cleared, because all three paths hand one straight back - the only exception
+    /// being a vote with <c>GiveKnife: false</c>, which now genuinely leaves the player without one
+    /// rather than silently keeping the spawn knife as it did before.
+    /// </remarks>
+    public void ClearAllocatedWeapons()
+    {
+        if (!player.Controller.IsValid || !CCsPlayerController.PawnIsAlive)
+        {
+            return;
+        }
+
+        CCsPlayerController.RemoveItemBySlot(gear_slot_t.GEAR_SLOT_RIFLE);
+        CCsPlayerController.RemoveItemBySlot(gear_slot_t.GEAR_SLOT_PISTOL);
+        CCsPlayerController.RemoveItemBySlot(gear_slot_t.GEAR_SLOT_GRENADES);
+        CCsPlayerController.RemoveItemBySlot(gear_slot_t.GEAR_SLOT_KNIFE);
+    }
+
+    private bool CanAllocate() =>
+        player.Controller.IsValid
+        && CCsPlayerController.PawnIsAlive
+        && CCsPlayerController.Team is >= CsTeam.Terrorist and <= CsTeam.CounterTerrorist;
+
+    /// <summary>
+    /// Swaps just the primary for the one the loadout now names, leaving the pistol, knife,
+    /// grenades and bomb untouched. Used when a saved loadout changed only that slot.
+    /// </summary>
+    /// <remarks>
+    /// Does nothing while <see cref="ShouldGiveAwp"/> is set: that player's rifle this round came
+    /// from the AWP roll and not from their loadout, so swapping it would quietly take the AWP away.
+    /// </remarks>
+    public void ReplacePrimary()
+    {
+        if (!CanAllocate() || ShouldGiveAwp)
+        {
+            return;
+        }
+
+        var item = CCsPlayerController.Team == CsTeam.Terrorist
+            ? PrimaryT[PrimaryWeaponT].Item
+            : PrimaryCt[PrimaryWeaponCt].Item;
+
+        CCsPlayerController.RemoveItemBySlot(gear_slot_t.GEAR_SLOT_RIFLE);
+        CCsPlayerController.GiveNamedItem(item);
+    }
+
+    /// <summary>As <see cref="ReplacePrimary"/>, for the pistol slot.</summary>
+    public void ReplaceSecondary()
+    {
+        if (!CanAllocate() || ShouldGiveAwp)
+        {
+            return;
+        }
+
+        var item = CCsPlayerController.Team == CsTeam.Terrorist
+            ? PistolsT[SecondaryWeaponT].Item
+            : PistolsCT[SecondaryWeaponCt].Item;
+
+        CCsPlayerController.RemoveItemBySlot(gear_slot_t.GEAR_SLOT_PISTOL);
+        CCsPlayerController.GiveNamedItem(item);
     }
 
     public void AllocateArmor(bool giveFull = true)

--- a/Modules/Weapons/LoadoutPanel.cs
+++ b/Modules/Weapons/LoadoutPanel.cs
@@ -1,5 +1,6 @@
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
 using Microsoft.Extensions.Logging;
 using PanoramaManager;
 using RetakesAllocator.Modules.Models;
@@ -54,6 +55,15 @@ public static class LoadoutPanel
         public int SecondaryCt;
         public GiveAwp Awp;
         public bool Dirty;
+
+        /// <summary>
+        /// What was saved last, so a save can tell which slots actually changed and re-issue only
+        /// those. Re-baselined after each save, so saving twice does not re-apply the first edit.
+        /// </summary>
+        public int SavedPrimaryT;
+        public int SavedPrimaryCt;
+        public int SavedSecondaryT;
+        public int SavedSecondaryCt;
     }
 
     public static void Init()
@@ -128,20 +138,28 @@ public static class LoadoutPanel
 
         ClampToLists(draft);
 
+        draft.SavedPrimaryT = draft.PrimaryT;
+        draft.SavedPrimaryCt = draft.PrimaryCt;
+        draft.SavedSecondaryT = draft.SecondaryT;
+        draft.SavedSecondaryCt = draft.SecondaryCt;
+
         Drafts[player.Slot] = draft;
 
-        // A fresh open re-applies every icon class from scratch, so a slot reused by a different
-        // player never inherits the previous occupant's tiles.
-        AppliedIcons.Remove(player.Slot);
-
-        Render(player, draft);
+        // Open BEFORE rendering. Per-player writes made while the panel is not yet open for that
+        // player never reach them - only global state survives - so rendering first draws an empty
+        // card and, worse, leaves AppliedIcons believing it already applied every icon class, which
+        // makes the icons permanently missing rather than merely late.
         _panel.Open(player);
+        Render(player, draft);
     }
 
     public static void OnPlayerDisconnect(int slot)
     {
+        // The draft is per session and goes. The icon record is NOT cleared: it mirrors class state
+        // that lives on the entity per slot, and that outlives both the menu closing and the player
+        // leaving. Forgetting it here would leave the next occupant's tiles wearing two icons,
+        // since we would no longer know which one to take off.
         Drafts.Remove(slot);
-        AppliedIcons.Remove(slot);
     }
 
     /// <summary>Redraws every open card. Used after a config reload changes the weapon lists.</summary>
@@ -174,6 +192,9 @@ public static class LoadoutPanel
         // back - it never saw what those ids meant.
         if (e.Action == PanelAction.Restored)
         {
+            // The entity is a new one, so nothing we ever applied is on it. Drop the icon record
+            // before redrawing or the diff will skip every class it thinks is already set.
+            AppliedIcons.Clear();
             RefreshOpen();
             return;
         }
@@ -246,6 +267,25 @@ public static class LoadoutPanel
         allocator.SecondaryWeaponCt = draft.SecondaryCt;
         allocator.GiveAwp = draft.Awp;
 
+        // Hand the new loadout over now rather than at the next spawn - a menu whose result only
+        // shows up a round later is hard to tell apart from one that did not save. Only the slots
+        // that changed for the team being played are re-issued: editing the CT columns while on T
+        // touches nothing, and changing only the rifle leaves the pistol in hand.
+        var terrorist = player.Team == CsTeam.Terrorist;
+
+        playerObj.ApplyLoadoutChange(
+            primaryChanged: terrorist
+                ? draft.PrimaryT != draft.SavedPrimaryT
+                : draft.PrimaryCt != draft.SavedPrimaryCt,
+            secondaryChanged: terrorist
+                ? draft.SecondaryT != draft.SavedSecondaryT
+                : draft.SecondaryCt != draft.SavedSecondaryCt);
+
+        draft.SavedPrimaryT = draft.PrimaryT;
+        draft.SavedPrimaryCt = draft.PrimaryCt;
+        draft.SavedSecondaryT = draft.SecondaryT;
+        draft.SavedSecondaryCt = draft.SecondaryCt;
+
         draft.Dirty = false;
 
         // Read the CounterStrikeSharp-bound values on the game thread before going async.
@@ -260,32 +300,29 @@ public static class LoadoutPanel
         };
 
         var slot = player.Slot;
-        _panel!.SetVariableFor(player, "status", "Saving...");
+
+        // Close on save. The picks are already live on the allocator, so the card has nothing left
+        // to show, and the confirmation belongs in chat where it survives the panel going away.
+        _panel!.Close(player);
+        PrintToChat(player, $"{Prefix} Loadout saved.");
 
         Task.Run(async () =>
         {
-            string status;
-
             try
             {
                 await Store.SaveUserAsync(pref);
-                status = "Saved to your profile";
+                return;
             }
             catch (Exception e)
             {
                 Plugin.Logger.LogError(e, "Failed to save weapon preferences for {SteamId}", pref.Auth);
-                status = "Could not save - your picks apply to this session only";
             }
 
-            // Native calls are not thread-safe: come back to the game thread before touching the
-            // panel, and only if the player still has it open.
+            // Native calls are not thread-safe: come back to the game thread to talk to the player.
+            // Only the failure is reported here - success was already confirmed above, and making
+            // players wait on a database round trip to see it would be worse.
             Server.NextFrame(() =>
             {
-                if (_panel == null || !Drafts.ContainsKey(slot))
-                {
-                    return;
-                }
-
                 var current = Utilities.GetPlayerFromSlot(slot);
 
                 if (current == null || !current.IsValid)
@@ -293,7 +330,7 @@ public static class LoadoutPanel
                     return;
                 }
 
-                _panel.SetVariableFor(current, "status", status);
+                PrintToChat(current, $"{Prefix} Your loadout could not be stored - it applies to this session only.");
             });
         });
     }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@ WeaponsAllocator plugin for retakes written in C# (.NET 10) for CounterStrikeSha
 
 This plugin runs alongside B3none's retakes implementation: https://github.com/b3none/cs2-retakes
 
+## Requirements
+
+- **CounterStrikeSharp on .NET 10** (API 1.0.373 or newer). The loadout menu is driven through
+  [PanoramaManager](https://www.nuget.org/packages/PanoramaManager), which targets `net10.0`, and
+  CounterStrikeSharp itself moved there at 1.0.373.
+- **[MultiAddonManager](https://github.com/Source2ZE/MultiAddonManager)** — required for the
+  loadout menu.
+- **The HUD workshop addon:
+  [Retakes Allocator - HUD](https://steamcommunity.com/sharedfiles/filedetails/?id=3792297574)**
+  (`3792297574`).
+
+The menu is a Panorama layout, which means it is drawn from a file on the **client**. The server
+cannot send it: it can only point at a layout the client already has, then write text into it and
+toggle classes on it. A CS2 server otherwise distributes only its map addon, so MultiAddonManager is
+what gets the layout to players alongside the map.
+
+Add the addon in `game/csgo/cfg/multiaddonmanager/multiaddonmanager.cfg`:
+
+```
+mm_extra_addons 3792297574
+```
+
+The addon is client-side content only, so `mm_client_extra_addons` also works and skips the
+server-side mount, at the cost of applying only to new connections. Either list takes effect on a
+map reload, and clients download the addon when they connect.
+
+Without it the plugin still allocates weapons normally — it logs the failure at load and tells
+players the menu is unavailable, rather than opening nothing.
+
+> The addon carries the compiled layout, so **any change under `hud/` needs the addon republished**
+> and re-downloaded by clients. Ship the plugin and the HUD together: the plugin drives panels by
+> id, and an id it expects that the layout does not have fails silently on both sides.
+
 ## Loadout menu
 
 `css_guns`, `css_pistols` and `css_awp` all open the same Panorama card: primary, secondary and
@@ -24,12 +57,22 @@ python hud/make_previews.py            # render it to hud/previews/ in a browser
 
 `--tiles` is the ceiling on a configured weapon list *and* the card width: Panorama cannot wrap
 and the server cannot create panels, so a list longer than the tile count is truncated. Build with
-the number your `Weapons` config actually uses. Changing it means recompiling and redeploying the
-VPK, not just the plugin.
+the number your `Weapons` config actually uses. Changing it means recompiling and republishing the
+addon, not just the plugin.
 
-> The retail client still refuses addon-supplied layouts, so today the compiled layout has to
-> reach clients through a `gameinfo.gi` search path. If the layout is missing the plugin logs the
-> failure, keeps allocating weapons, and tells players the menu is unavailable.
+### Building the layout
+
+Compiling needs `resourcecompiler.exe`, which ships with CS2 in `game\bin\win64` — Workshop Tools
+is a GUI over it, and is not required:
+
+```
+# stage hud/panorama into content\csgo_addons\retakes_allocator\, then
+.\cs2-panorama-hud\scripts\build-hud.ps1 -Cs2Root "<CS2 install>" -Addon retakes_allocator
+```
+
+Sources are `.xml` and `.css`; the compiler emits `.vxml_c` and `.vcss_c` into the matching
+`game\csgo_addons\...` tree. That compiled `panorama/` folder is what gets published to the
+workshop addon. Publish it from Workshop Tools under the same `retakes_allocator` source folder.
 
 ## Config
 

--- a/hud/panorama/styles/custom_game/alloc_menu.css
+++ b/hud/panorama/styles/custom_game/alloc_menu.css
@@ -171,15 +171,20 @@
 	background-color: #9ccf4f18;
 }
 .am-save:hover { background-color: #9ccf4f30; brightness: 1.2; sound: "UIPanorama.ButtonRollover"; }
+/* Centring text in a button takes two different properties, and vertical-align is neither of them
+   for the vertical axis: it positions the PANEL within its parent, not the text within the label.
+   Horizontally it is text-align; vertically it is line-height set to the label's own height, which
+   is how Valve does it (popup_capability_can_stattrack_swap: height 256px, line-height 147px).
+   line-height must track .am-save's height - 30px - if that ever changes. */
 .am-save-l
 {
 	width: 100%;
 	height: 100%;
+	line-height: 30px;
 	font-family: Stratum2 Medium Condensed;
 	font-size: 14px;
 	color: #9ccf4f;
 	text-transform: uppercase;
 	letter-spacing: 2px;
 	text-align: center;
-	vertical-align: center;
 }


### PR DESCRIPTION
Everything v3.0.0 shipped was untested in game. This is what it took to make it actually work, found in the order the failures surface on a live server.

## The card drew nothing

`Open()` rendered **before** `_panel.Open(player)`. Per-player writes made while the panel is not yet open for that player never reach them — only global state does. So the card showed its title, the AWP glyphs and the hint (all global) but no weapon names, no icons, every tile visible and no status line, filling in only once a click re-rendered it while open.

That also explains why icons never appeared *even after* a click: the lost first render still populated `AppliedIcons`, and the icon write is the one guarded by that record. The record now tracks what it actually mirrors — class state living on the entity per slot, which outlives the menu closing and the player leaving — and is dropped on `Restored`, where the entity really is rebuilt.

## Nothing was allocated at all

`OnPlayerSpawn` returned early during warmup, and newer retakes builds spawn players there, so it bailed before queueing the timer. Warmup now allocates, skipping the pistol round (counted from round 0) and the vote (which belongs to the match).

`OnRoundPreStart` bailed on warmup too — less visibly, but `ResetNades()` never ran, so the pool shared by every player drains across warmup respawns and never refills. No AWP is handed out in warmup: nobody wins a roll for a round that is not played.

## Then everyone got two of everything

`player_spawn` fires more than once around a single spawn, each queued its own timer, and every allocation path only ever gives. One timer per player now, replaced rather than added — plus the sturdier fix: clear the slots allocation refills (rifle, pistol, grenades, knife) before filling them.

Deliberately **not** `RemoveWeapons()`, which also takes the C4 that retakes hands a terrorist at round start, before this runs. The bomb has its own slot and is never cleared.

## Save applies now

Saving closes the card, confirms in chat, and re-issues the loadout on the spot — but only the slots that changed for the team being played. Editing the CT columns while on T touches nothing; changing only the rifle leaves the pistol in hand; a player holding the AWP from the round's roll keeps it.

## Behaviour changes worth noting

- A vote with `GiveKnife: false` now genuinely leaves the player without one. Previously they silently kept their spawn knife, so the setting did nothing. Defaults are unaffected — `GiveKnife` defaults to `true` and both shipped votes set it.
- The README's claim that retail clients refuse addon-supplied layouts is false: the published UI-only addon reaches clients. Replaced with MultiAddonManager setup and the real build-and-publish steps.

## Verification

Layout validator and the plugin/layout contract check both pass. **Tests were not run locally** — Windows Smart App Control is enforcing on the dev machine and blocks freshly-built assemblies at load, so `dotnet test` fails identically on an unmodified checkout. CI is the real signal here.